### PR TITLE
Add SetPassword method to Encryptor

### DIFF
--- a/StreamEncryptor.Tests/EncryptorTests.cs
+++ b/StreamEncryptor.Tests/EncryptorTests.cs
@@ -88,6 +88,9 @@ namespace StreamEncryptor.Tests
         {
             using (var encryptor = GetEncryptor())
             {
+                Assert.Throws<ArgumentNullException>(() => encryptor.SetPassword(null));
+                Assert.Throws<ArgumentNullException>(() => encryptor.SetPassword(string.Empty));
+
                 MemoryStream ms = await Constants.GetEncryptedStream();
                 encryptor.SetPassword(Constants.PASSWORD.Reverse().ToString());
                 Assert.False(await encryptor.AuthenticateAsync(ms));

--- a/StreamEncryptor.Tests/EncryptorTests.cs
+++ b/StreamEncryptor.Tests/EncryptorTests.cs
@@ -83,6 +83,17 @@ namespace StreamEncryptor.Tests
             }
         }
 
+        [Fact]
+        public async void TestSetPassword()
+        {
+            using (var encryptor = GetEncryptor())
+            {
+                MemoryStream ms = await Constants.GetEncryptedStream();
+                encryptor.SetPassword(Constants.PASSWORD.Reverse().ToString());
+                Assert.False(await encryptor.AuthenticateAsync(ms));
+            }
+        }
+
         private Encryptor<AesCryptoServiceProvider, HMACSHA256> GetEncryptor()
         {
             return new Encryptor<AesCryptoServiceProvider, HMACSHA256>(Constants.PASSWORD);

--- a/StreamEncryptor/Encryptor.cs
+++ b/StreamEncryptor/Encryptor.cs
@@ -355,6 +355,22 @@ namespace StreamEncryptor
 
         #endregion
 
+        /// <summary>
+        /// Updates the password used for encryption/decryption
+        /// </summary>
+        /// <param name="newPassword"></param>
+        /// <remarks>This method is useful when using patterns like dependency injection. 
+        /// Note that decrypting a stream requires the same password that was used to encrypt it
+        /// </remarks>
+        public void SetPassword(string newPassword)
+        {
+            CheckDisposed();
+            if (string.IsNullOrEmpty(newPassword))
+                throw new ArgumentNullException(nameof(newPassword), "Password may not be null or empty!");
+
+            _password = newPassword;
+        }
+
         protected void SetupConfiguration()
         {
             _encryptor.Mode = Configuration.Mode;

--- a/StreamEncryptor/StreamEncryptor.csproj
+++ b/StreamEncryptor/StreamEncryptor.csproj
@@ -13,6 +13,8 @@
     <NeutralLanguage>en-NZ</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/carlst99/StreamEncryptor/blob/master/LICENSE</PackageLicenseUrl>
+    <Version>1.1.0</Version>
+    <PackageReleaseNotes>Performance enhancements - you can now pass an output stream directly to the EncryptAsync and DecryptAsync methods of an Encryptor</PackageReleaseNotes>
   </PropertyGroup>
 
 </Project>

--- a/StreamEncryptor/StreamEncryptor.csproj
+++ b/StreamEncryptor/StreamEncryptor.csproj
@@ -13,7 +13,7 @@
     <NeutralLanguage>en-NZ</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/carlst99/StreamEncryptor/blob/master/LICENSE</PackageLicenseUrl>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageReleaseNotes>Performance enhancements - you can now pass an output stream directly to the EncryptAsync and DecryptAsync methods of an Encryptor</PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
This method allows the internal password used by the encryptor to be updated after instantiation.
This is useful when using an Encryptor in conjunction with patterns like dependency injection.