### PR TITLE
Fix various logic issues

### DIFF
--- a/StreamEncryptor.Tests/EncryptorAuthenticationTests.cs
+++ b/StreamEncryptor.Tests/EncryptorAuthenticationTests.cs
@@ -42,7 +42,7 @@ namespace StreamEncryptor.Tests
                 MemoryStream encrypted = await encryptor.EncryptAsync<MemoryStream>(ms).ConfigureAwait(false);
 
                 var result = await encryptor.AuthenticateAsync(encrypted, false).ConfigureAwait(false);
-                Assert.NotNull(result.RemainingStream);
+                Assert.NotNull(result.Buffer);
                 Assert.True(result.AuthenticationSuccess);
                 Assert.True(encrypted.Position != 0);
             }
@@ -69,7 +69,7 @@ namespace StreamEncryptor.Tests
                 MemoryStream encrypted = await encryptor.EncryptAsync<MemoryStream>(ms).ConfigureAwait(false);
 
                 var result = await encryptor.AuthenticateAsync(encrypted, true).ConfigureAwait(false);
-                Assert.Null(result.RemainingStream);
+                Assert.Null(result.Buffer);
             }
         }
 

--- a/StreamEncryptor.Tests/EncryptorTests.cs
+++ b/StreamEncryptor.Tests/EncryptorTests.cs
@@ -94,6 +94,9 @@ namespace StreamEncryptor.Tests
                 MemoryStream ms = await Constants.GetEncryptedStream();
                 encryptor.SetPassword(Constants.PASSWORD.Reverse().ToString());
                 Assert.False(await encryptor.AuthenticateAsync(ms));
+
+                encryptor.SetPassword(Constants.PASSWORD);
+                Assert.True(await encryptor.AuthenticateAsync(ms));
             }
         }
 

--- a/StreamEncryptor/Encryptor.cs
+++ b/StreamEncryptor/Encryptor.cs
@@ -127,7 +127,7 @@ namespace StreamEncryptor
 
                 #endregion
 
-                MemoryStream remainingStream = new MemoryStream(authenticationResult.RemainingStream);
+                MemoryStream remainingStream = new MemoryStream(authenticationResult.Buffer);
 
                 #region Get IVs, Keys and hashes
 
@@ -149,7 +149,7 @@ namespace StreamEncryptor
                 {
                     byte[] buff = new byte[Configuration.BufferSize];
 
-                    while (cs.Read(buff, 0, buff.Length) != 0)
+                    while (cs.Read(buff, 0, buff.Length) > 0)
                     {
                         await outputStream.WriteAsync(buff, 0, buff.Length).ConfigureAwait(false);
                     }

--- a/StreamEncryptor/Encryptor.cs
+++ b/StreamEncryptor/Encryptor.cs
@@ -149,11 +149,10 @@ namespace StreamEncryptor
                 {
                     byte[] buff = new byte[Configuration.BufferSize];
 
-                    cs.Read(buff, 0, buff.Length);
-                    do
+                    while (cs.Read(buff, 0, buff.Length) != 0)
                     {
                         await outputStream.WriteAsync(buff, 0, buff.Length).ConfigureAwait(false);
-                    } while (cs.Read(buff, 0, buff.Length) != 0);
+                    }
                 }
 
                 #endregion

--- a/StreamEncryptor/Encryptor.cs
+++ b/StreamEncryptor/Encryptor.cs
@@ -149,10 +149,11 @@ namespace StreamEncryptor
                 {
                     byte[] buff = new byte[Configuration.BufferSize];
 
-                    while (cs.Read(buff, 0, buff.Length) != 0)
+                    cs.Read(buff, 0, buff.Length);
+                    do
                     {
                         await outputStream.WriteAsync(buff, 0, buff.Length).ConfigureAwait(false);
-                    }
+                    } while (cs.Read(buff, 0, buff.Length) != 0);
                 }
 
                 #endregion

--- a/StreamEncryptor/Encryptor.cs
+++ b/StreamEncryptor/Encryptor.cs
@@ -107,7 +107,7 @@ namespace StreamEncryptor
 
             if (encryptedStream.IsNullOrEmpty())
                 throw new ArgumentNullException(nameof(encryptedStream), "Stream cannot be null or empty");
-            if (encryptedStream == null)
+            if (outputStream == null)
                 throw new ArgumentNullException(nameof(outputStream));
 
             try

--- a/StreamEncryptor/Helpers/AuthenticationResult.cs
+++ b/StreamEncryptor/Helpers/AuthenticationResult.cs
@@ -2,13 +2,13 @@
 {
     internal struct AuthenticationResult
     {
-        public byte[] RemainingStream;
+        public byte[] Buffer;
         public bool AuthenticationSuccess;
 
         public AuthenticationResult(bool result, byte[] remainingStream)
         {
             AuthenticationSuccess = result;
-            RemainingStream = remainingStream;
+            Buffer = remainingStream;
         }
     }
 }

--- a/StreamEncryptor/StreamEncryptor.csproj
+++ b/StreamEncryptor/StreamEncryptor.csproj
@@ -13,7 +13,7 @@
     <NeutralLanguage>en-NZ</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/carlst99/StreamEncryptor/blob/master/LICENSE</PackageLicenseUrl>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <PackageReleaseNotes>Adds the SetPassword method to Encryptor</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/StreamEncryptor/StreamEncryptor.csproj
+++ b/StreamEncryptor/StreamEncryptor.csproj
@@ -13,7 +13,7 @@
     <NeutralLanguage>en-NZ</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/carlst99/StreamEncryptor/blob/master/LICENSE</PackageLicenseUrl>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <PackageReleaseNotes>Adds the SetPassword method to Encryptor</PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR renames AuthenticationResult.RemainingStream to Buffer, to more accurately represent what is being stored by the variable.
Additionally, a few small logic issues are fixed, including removing the double-null check that was happening in DecryptAsync