### PR TITLE
Improvements to EncryptorConfiguration

### DIFF
--- a/StreamEncryptor.Tests/EncryptorConfigurationTests.cs
+++ b/StreamEncryptor.Tests/EncryptorConfigurationTests.cs
@@ -20,5 +20,16 @@ namespace StreamEncryptor.Tests
             Assert.Equal(EncryptorConfiguration.Default.SaltSize, configuration.SaltSize);
             Assert.Equal(EncryptorConfiguration.Default.BufferSize, configuration.BufferSize);
         }
+
+        [Fact]
+        public void TestCheckConfiguration()
+        {
+            EncryptorConfiguration configuration = EncryptorConfiguration.Default;
+            Assert.True(configuration.CheckConfigValid());
+
+            configuration = new EncryptorConfiguration(System.Security.Cryptography.CipherMode.CBC,
+                System.Security.Cryptography.PaddingMode.PKCS7, 0, 0, 0);
+            Assert.False(configuration.CheckConfigValid());
+        }
     }
 }

--- a/StreamEncryptor/Encryptor.cs
+++ b/StreamEncryptor/Encryptor.cs
@@ -55,6 +55,8 @@ namespace StreamEncryptor
         {
             if (string.IsNullOrEmpty(password))
                 throw new ArgumentNullException(nameof(password), "Key may not be null or empty");
+            if (!configuration.CheckConfigValid())
+                throw new InvalidOperationException("Invalid configuration specified!");
 
             _password = password;
             Configuration = configuration;

--- a/StreamEncryptor/EncryptorConfiguration.cs
+++ b/StreamEncryptor/EncryptorConfiguration.cs
@@ -50,5 +50,20 @@ namespace StreamEncryptor
         }
 
         public int GetKeySizeInBits() => KeySize * BIT_MULTIPLIER;
+
+        public int GetSaltSizeInBits() => SaltSize * BIT_MULTIPLIER;
+
+        /// <summary>
+        /// Checks that this configuration is valid
+        /// </summary>
+        /// <returns></returns>
+        public bool CheckConfigValid()
+        {
+            return BufferSize > 0
+                && KeySize > 0
+                && SaltSize > 0;
+        }
+
+
     }
 }

--- a/StreamEncryptor/EncryptorConfiguration.cs
+++ b/StreamEncryptor/EncryptorConfiguration.cs
@@ -12,7 +12,7 @@ namespace StreamEncryptor
             Padding = PaddingMode.PKCS7,
             KeySize = 32,
             SaltSize = 16,
-            BufferSize = 81920
+            BufferSize = 40960
         };
 
         /// <summary>

--- a/StreamEncryptor/StreamEncryptor.csproj
+++ b/StreamEncryptor/StreamEncryptor.csproj
@@ -13,7 +13,7 @@
     <NeutralLanguage>en-NZ</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/carlst99/StreamEncryptor/blob/master/LICENSE</PackageLicenseUrl>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
     <PackageReleaseNotes>Adds the SetPassword method to Encryptor</PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR reduces the default size of the ```EncryptorConfigurationBuffer``` property.

It also adds the ```EncryptorConfiguration.CheckValidConfig()``` method, to ensure that a configuration is valid. So far, these checks are very basic and consist only of checking that any size-related variables are greater than zero.